### PR TITLE
Added CuBox-I dualcore support

### DIFF
--- a/content/etc/init/module-init-tools.override
+++ b/content/etc/init/module-init-tools.override
@@ -11,15 +11,45 @@ pre-start script
     [ -z "$CPUFREQ_GOVERNOR" ] && CPUFREQ_GOVERNOR="$PREVIOUS_GOVERNOR"
     if [ $(xbian-arch) = RPI ]; then
         modprobe vchiq
-        echo powersave > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
     fi
+    I=0
+    ERROR=0
+    while [ -f /sys/devices/system/cpu/cpu$I/cpufreq/scaling_governor ]; do
+        echo powersave > /sys/devices/system/cpu/cpu$I/cpufreq/scaling_governor
+        ERROR=$?
+        if [ $ERROR -ne 0 ]; then
+            break;
+        fi
+        I=$(($I+1))
+    done
     modprobe -q cpufreq_${CPUFREQ_GOVERNOR} || :
     # Note: in case the user specifies an invalid governor, the kernel is
     # intelligent enough to not change the current valid governor.  That said,
     # we need to restore the previous one as we changed it to "powersave" on the
     # Raspberry Pi (see above).
-    echo $CPUFREQ_GOVERNOR > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
-    [ $? -ne 0 ] && echo $PREVIOUS_GOVERNOR > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor || :
+    I=0
+    ERROR=0
+    while [ -f /sys/devices/system/cpu/cpu$I/cpufreq/scaling_governor ]; do
+        echo $CPUFREQ_GOVERNOR > /sys/devices/system/cpu/cpu$I/cpufreq/scaling_governor
+        ERROR=$?
+        if [ $ERROR -ne 0 ]; then
+            break;
+        fi        
+        I=$(($I+1))
+    done    
+
+    if [ $ERROR -ne 0 ]; then
+        I=0
+        ERROR=0
+        while [ -f /sys/devices/system/cpu/cpu$I/cpufreq/scaling_governor ]; do
+            echo $PREVIOUS_GOVERNOR > /sys/devices/system/cpu/cpu$I/cpufreq/scaling_governor
+            ERROR=$?
+            if [ $ERROR -ne 0 ]; then
+                break;
+            fi        
+            I=$(($I+1))
+        done
+    fi
 
     [ -e /etc/modules.xbian ] || exit 0
     grep '^[^#]' /etc/modules.xbian |


### PR DESCRIPTION
The Hummingboard can have a dual core CPU. Therefor we must check for multiple CPU cores. These commit will let the init scripts check for all cores dynamically so it will also support quad and octo cores :smile:
