### PR TITLE
Accept spaces in samba path in /etc/fstab

### DIFF
--- a/content/etc/init/autofs-rebuild.conf
+++ b/content/etc/init/autofs-rebuild.conf
@@ -18,6 +18,7 @@ script
                 echo "$b -fstype=$c,$d $a" >> $MAPFILE
                 ;;
             cifs)
+                a=$(echo $a | sed 's/\040/\\ /g')
                 echo "$b -fstype=$c,$d :$a" >> $MAPFILE
                 ;;
             *)


### PR DESCRIPTION
Spaces in Samba paths should be written as "\040" in /etc/fstab, while automount expects "\ ". Added simple sed substitution to make the conversion.
