### PR TITLE
Tentative fix for xbianonpi/xbian#609

### DIFF
--- a/content/DEBIAN/postinst
+++ b/content/DEBIAN/postinst
@@ -656,8 +656,7 @@ EOF
 
             sed -e '1,/^Match /w /etc/ssh/ssh_config.head
 /^Match /,$w /etc/ssh/sshd_config.tail'
-            sed  -e '/^AddressFamily \|^UseDNS \|^Match /d' /etc/ssh/ssh_config.head > /etc/ssh/sshd_config.new.2
-            echo "AddressFamily inet" >> /etc/ssh/sshd_config.new.2
+            sed  -e '/^UseDNS \|^Match /d' /etc/ssh/ssh_config.head > /etc/ssh/sshd_config.new.2
             echo "UseDNS no" >> /etc/ssh/sshd_config.new.2
             cat /etc/ssh/sshd_config.tail>>/etc/ssh/sshd_config.new.2
             mv /etc/ssh/sshd_config.new.2 /etc/ssh/sshd_config


### PR DESCRIPTION
This should solve the case where sshd_config has "Match ..." stanzas.
TO-DO: I'd like to have it split before any adjacent comment lines before the first "Match ...", because these might document the Match itself.

(This is my first git pull request... please let me know if I am doing something wrong!)
