### PR TITLE
udhcpc: always send DHCP hostname

### DIFF
--- a/content/etc/xbian-udhcpc/xbian-dhcp
+++ b/content/etc/xbian-udhcpc/xbian-dhcp
@@ -17,8 +17,9 @@ case $1 in
         ip link set ${interface} up || :
 
         [ -z "$METHOD" ] && METHOD=dhcp
+        [ -z "$dhcp_hostname" ] && dhcp_hostname=$(hostname -s)
         echo DHCPDISCOVER >&2
-        ipconfig -t 60 -d $interface -c $METHOD 1>&2
+        ipconfig -t 60 -d $interface -c $METHOD "::::${dhcp_hostname}::" 1>&2
         [ $? -eq 124 ] && { echo Terminated >&2; ip link set $interface down || :; exit 1; }
         echo bound >&2
 

--- a/content/usr/local/sbin/xbian-udhcpc
+++ b/content/usr/local/sbin/xbian-udhcpc
@@ -4,7 +4,7 @@ env >> /run/xbian-udhcpc.$IFACE
 echo "command parameters $@" >> /run/xbian-udhcpc.$IFACE
 
 while test $# -ne '0'; do
-    case $1 in 
+    case $1 in
         -n)
             shift
             ;;
@@ -15,10 +15,15 @@ while test $# -ne '0'; do
         -i)
             shift 2
             ;;
+        -H)
+            dhcp_hostname=$2
+            shift 2
+            ;;
     esac
 done
 
 trap '' USR2
-pidfile=$PID interface=$IFACE /etc/xbian-udhcpc/xbian-dhcp renew & echo $! > $PID
+pidfile=$PID interface=$IFACE dhcp_hostname=$dhcp_hostname \
+    /etc/xbian-udhcpc/xbian-dhcp renew & echo $! > $PID
 wait $!
 exit $?


### PR DESCRIPTION
this makes it easy for a local router/server to identify clients and update for example its internal DNS resolver (also matching dhclient behavior in jessie)
