### PR TITLE
Properly handle spaces in nfs and cifs mounts

### DIFF
--- a/content/etc/init/autofs-rebuild.conf
+++ b/content/etc/init/autofs-rebuild.conf
@@ -15,10 +15,13 @@ script
         [ "$b" != '/' ] || continue
         case $c in
             nfs|nfs4)
+                a=$(echo $a | sed 's/\040/\\ /g')
+                b=$(echo $b | sed 's/\040/\\ /g')
                 echo "$b -fstype=$c,$d $a" >> $MAPFILE
                 ;;
             cifs)
                 a=$(echo $a | sed 's/\040/\\ /g')
+                b=$(echo $b | sed 's/\040/\\ /g')
                 echo "$b -fstype=$c,$d :$a" >> $MAPFILE
                 ;;
             *)


### PR DESCRIPTION
nfs shares with spaces get completely mangled. This fixes spaces in remote and local mount points

Test line for fstab
192.168.0.1:/mnt/Spaces\0402 /mnt/Spaces\0402 nfs defaults,rw,nolock 0 0
