### PR TITLE
autofs spams /var/log/upstart/autofs.log

### DIFF
--- a/content/etc/init/autofs.conf
+++ b/content/etc/init/autofs.conf
@@ -27,7 +27,7 @@ script
         . /etc/default/autofs
     fi
 
-    exec $DAEMON -p $PIDFILE -v -d $OPTIONS -f
+    exec $DAEMON -p $PIDFILE $OPTIONS -f
 end script
 
 post-start exec initctl emit -n autofs || :


### PR DESCRIPTION
Removing the -v -d start option in /etc/init/autofs.conf solves the issue only temporarely, because after each running an update (package xbian-update) my modification has gone.
I think it would be better to put these options into /etc/default/autofs variable OPTION so everybody who likes to have log-spam can enable this