### PR TITLE
Removed SuperRepo for Kodi compliance

### DIFF
--- a/content-tpl/DEBIAN/postinst
+++ b/content-tpl/DEBIAN/postinst
@@ -863,7 +863,7 @@ if [ $1 == "configure" ]; then
 
         rmlibshairport
         
-        superRepo
+	:   # SuperRepo removed for Kodi compliancy
 
 	if [ -e /dev/rtc0 ]; then
 	    grep -q "UTC" /etc/default/rcS || echo -e "\nUTC=yes\n" >> /etc/default/rcS

--- a/content-tpl/DEBIAN/postinst
+++ b/content-tpl/DEBIAN/postinst
@@ -255,10 +255,8 @@ version1011() {
 
 	echo "7) Adding SuperRepo"
 
-	:
-	
-	# SuperRepo removed for Kodi compliancy
-	
+	:   # SuperRepo removed for Kodi compliancy
+
 	echo "8) Modifying avahi-deamon defaults"
 
 	if [ $(grep "AVAHI_DAEMON_DETECT_LOCAL=1"  /etc/default/avahi-daemon| wc -l) -eq 1 ];	then

--- a/content-tpl/DEBIAN/postinst
+++ b/content-tpl/DEBIAN/postinst
@@ -33,25 +33,6 @@ xbianGroups(){
     usermod -a -G audio,video,input xbian
 }
 
-superRepo(){
-        KODI="$(dpkg-query -W --showformat='${Package} %%${Origin}%% %%${Status}%% %%${Description}%%\n'  | grep -i '%%XBian%%' | grep '%%XBMC (' | grep -w '%%install ok installed%%' | cut -f 7 -d ' ' | tr -d '()' | cut -f 2 -d '/')"
-        [ -z "$KODI" ] && KODI="jarvis"
-        for SOURCESXML in $(find /home/xbian -name sources.xml); do
-           if [ $(grep "<name>SuperRepo.org Virtual Disk</name>" $SOURCESXML | wc -l) -eq 0 ]; then
-               sed -i --follow-symlinks "s|<files>|<files>\n\t<default pathversion=\"1\"></default>\n\t<source>\n\t\t<name>SuperRepo.org Virtual Disk</name>\n\t\t<path pathversion=\"1\">http://srp.nu/${KODI}/</path>\n\t</source>|g" $SOURCESXML
-               if [ $(grep "<name>SuperRepo.org Virtual Disk</name>" $SOURCESXML | wc -l) -eq 1 ]; then
-                   echo "Success: changed Fusion to SuperRepo in $SOURCESXML" >> /home/xbian/xbian-update.log;
-               else
-                   echo "Error: failed to change Fusion to SuperRepo $SOURCESXML" >> /home/xbian/xbian-update.log;
-               fi
-           else
-               echo "Notice: Updating SuperRepo URL in $SOURCESXML" >> /home/xbian/xbian-update.log;
-               sed -i -r "s|http://(use\|mirrors).superrepo.org/.*</path>|http://srp.nu/${KODI}/</path>|g" $SOURCESXML
-               sed -i "s|http://srp.nu/.*</path>|http://srp.nu/${KODI}/</path>|g" $SOURCESXML
-           fi
-        done
-}
-
 adaptAdvancedSettings(){
             if [ "$(stat --printf="%s" /home/xbian/.xbmc/userdata/advancedsettings.xml)" -eq 0 ]; then
 cat << \EOF > /home/xbian/.xbmc/userdata/advancedsettings.xml
@@ -274,7 +255,9 @@ version1011() {
 
 	echo "7) Adding SuperRepo"
 
-	superRepo
+	:
+	
+	# SuperRepo removed for Kodi compliancy
 	
 	echo "8) Modifying avahi-deamon defaults"
 


### PR DESCRIPTION
"To be compliant with Kodi rules, you can only ship those addons and the one repo that comes installed in vanilla Kodi."

Packages involved:
https://github.com/xbianonpi/xbian-update/
https://github.com/xbianonpi/xbian-package-xbmc/
https://github.com/xbianonpi/xbian-package-xbianhome/