### PR TITLE
network changes listening task sending SIGHUP to inetd to reread conf…

### DIFF
--- a/content/etc/init/openbsd-inetd-reconf-on-netchange.conf
+++ b/content/etc/init/openbsd-inetd-reconf-on-netchange.conf
@@ -1,0 +1,5 @@
+start on net-device-up
+
+task
+
+exec /sbin/reload openbsd-inetd


### PR DESCRIPTION
…iguration.

this helps with / fixes issues around services availability on ipv6 defined via inetd. the ipv6 takes usually longer to initialise than ipv4. so as inetd starts triggered by net config change, when it binds interfaces, ipv6 can still be in the process of bringing up. inetd then doesn't bind ipv6 sockets and services otherwise defined to be available on ipv6 are not available. 

(this task receives all changes from net devices - so once ipv6 up, it tells inetd to recheck config. inetd in the process also rebinds interfaces))

testing inetd.conf:
```
ssh  stream  tcp4  nowait  root   /usr/sbin/tcpd /usr/sbin/sshd -i

ssh  stream  tcp6  nowait  root   /usr/sbin/tcpd /usr/sbin/sshd -i -6
```

ssh on ipv6 after boot finally works.