### PR TITLE
Update rules for non root access to GPIO through /dev/gpiomem

### DIFF
--- a/content/lib/udev/rules.d/99-zz-xbian.rules
+++ b/content/lib/udev/rules.d/99-zz-xbian.rules
@@ -3,10 +3,6 @@ KERNEL=="uinput", GROUP="input", MODE="0664"
 SUBSYSTEM=="input", KERNEL=="mouse*|mice|event*", GROUP="input", MODE="0660"
 SUBSYSTEM=="net", ACTION=="add", ENV{INTERFACE}=="eth[0-9]|wlan[0-9]|ra[0-9]", RUN+="/usr/local/sbin/xbian-addnet %E{INTERFACE}"
 
-SUBSYSTEM=="bcm2835-gpiomem", GROUP="gpio", MODE="0660"
-SUBSYSTEM=="gpio", GROUP="gpio", MODE="0660"
-SUBSYSTEM=="gpio*", PROGRAM="/bin/sh -c '\
-        chown -R root:gpio /sys/class/gpio && chmod -R 770 /sys/class/gpio;\
-        chown -R root:gpio /sys/devices/virtual/gpio && chmod -R 770 /sys/devices/virtual/gpio;\
-        chown -R root:gpio /sys$devpath && chmod -R 770 /sys$devpath\
-'"
+SUBSYSTEM=="gpiomem", GROUP="gpio", MODE="0660"
+SUBSYSTEM=="gpiomem", KERNEL=="gpiochip*", ACTION=="add", PROGRAM="/bin/sh -c 'chgrp -R gpio /sys/class/gpio && chmod -R g=u /sys/class/gpio'"
+SUBSYSTEM=="gpiomem", ACTION=="add", PROGRAM="/bin/sh -c 'chgrp -R gpio /sys%p && chmod -R g=u /sys%p


### PR DESCRIPTION
As a followup to https://github.com/xbianonpi/xbian/issues/898 an update of the rules is needed to maintain non root access to GPIO through /dev/gpiomem

See https://github.com/RPi-Distro/raspberrypi-sys-mods/blob/master/etc.armhf/udev/rules.d/99-com.rules for the source

Tested and working fine on  XBian 11.0 - Bookworm - 20230803-0